### PR TITLE
Append component className to rendered rule className

### DIFF
--- a/modules/components/createComponent.js
+++ b/modules/components/createComponent.js
@@ -14,7 +14,8 @@ export default function createComponent(rule, type = 'div', passThroughProps = {
       return output
     }, { })
 
-    componentProps.className = renderer.renderRule(rule, felaProps)
+    const className = props.className ? props.className + ' ' : '';
+    componentProps.className = className + renderer.renderRule(rule, felaProps)
     return createElement(type, componentProps, children)
   }
 

--- a/modules/components/createComponent.js
+++ b/modules/components/createComponent.js
@@ -14,7 +14,8 @@ export default function createComponent(rule, type = 'div', passThroughProps = {
       return output
     }, { })
 
-    const className = props.className ? props.className + ' ' : '';
+    const className = props.className ? props.className + ' ' : ''
+    delete felaProps['className']
     componentProps.className = className + renderer.renderRule(rule, felaProps)
     return createElement(type, componentProps, children)
   }


### PR DESCRIPTION
This allows you to pass-through a className on your Fela component, to be used for purposes other than rendering Fela rules. The component's className will be appended to the Fela-generated className.